### PR TITLE
Add Nginx reverse proxy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,17 @@ services:
     env_file:
       - .env
     restart: unless-stopped
+  nginx:
+    image: nginx:alpine
+    container_name: nginx_proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    depends_on:
+      - app
   healthcheck:
     test: ["CMD", "wget", "-qO-", "http://${HOST}:${PORT}/health"]
     interval: 30s

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,41 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # Redirect HTTP to HTTPS
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    # HTTPS server block
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+        location / {
+            proxy_pass http://app:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Configure Nginx to redirect HTTP to HTTPS and proxy traffic to the app
- Add Nginx service to docker-compose with SSL certificate volume

## Testing
- `npm test` *(fails: SPOTIFY_CLIENT_ID manquant dans .env)*

------
https://chatgpt.com/codex/tasks/task_e_689cfc99f0d08324bee27d3a2c8614c6