### PR TITLE
feat: enforce https behind proxy

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -22,6 +22,7 @@ if (runtimeEnv) {
 dotenv.config();
 
 const app = express();
+app.set('trust proxy', 1);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,9 +32,18 @@ app.use(cors());
 app.use(cookieParser());
 app.use(express.json());
 
+// Redirection HTTPS si nécessaire
+if (process.env.NODE_ENV === 'production') {
+  app.use((req, res, next) => {
+    if (req.protocol !== 'https') {
+      return res.redirect(`https://${req.get('host')}${req.originalUrl}`);
+    }
+    next();
+  });
+}
+
 // Middlewares spécifiques production
 if (process.env.NODE_ENV === 'production') {
-  app.set('trust proxy', 1);
   app.use(helmet({ crossOriginResourcePolicy: false }));
   app.use(compression());
   // Cache basique pour assets statiques


### PR DESCRIPTION
## Summary
- trust first proxy to honor X-Forwarded-Proto
- redirect HTTP requests to HTTPS in production

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cfc9f4f6c8324890781ce6939dc89