### PR TITLE
feat: add unique player metric

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -60,6 +60,14 @@ npm run test:basic
 npm run test:jest
 ```
 
+### 📊 KPI Prometheus
+
+Le serveur expose des métriques pour Prometheus via `GET /metrics` :
+
+- `player_guesses_total` – nombre total de tentatives de devinettes.
+- `correct_guesses_total` – nombre de devinettes correctes.
+- `unique_players_total` – nombre de joueurs uniques.
+
 ### Corrections Principales Validées
 - **Fix erreur 500** : Les playlists privées retournent maintenant 403 au lieu de 500
 - **Gestion d'erreurs API** : Codes de statut Spotify correctement propagés

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "helmet": "^8.1.0",
+        "prom-client": "^15.1.3",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -1020,6 +1021,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -1682,6 +1692,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -4579,6 +4595,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5200,6 +5229,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "helmet": "^8.1.0",
+    "prom-client": "^15.1.3",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/src/server/utils/metrics.js
+++ b/src/server/utils/metrics.js
@@ -1,0 +1,41 @@
+import client from 'prom-client';
+
+const register = new client.Registry();
+
+const collectDefaultMetrics = () => client.collectDefaultMetrics({ register });
+
+const playerGuessesCounter = new client.Counter({
+  name: 'player_guesses_total',
+  help: 'Total number of guesses made by players',
+  registers: [register]
+});
+
+const correctGuessesCounter = new client.Counter({
+  name: 'correct_guesses_total',
+  help: 'Total number of correct guesses made by players',
+  registers: [register]
+});
+
+const uniquePlayers = new Set();
+
+const uniquePlayersCounter = new client.Counter({
+  name: 'unique_players_total',
+  help: 'Number of unique players',
+  registers: [register]
+});
+
+const trackUniquePlayer = (playerId) => {
+  if (!uniquePlayers.has(playerId)) {
+    uniquePlayers.add(playerId);
+    uniquePlayersCounter.inc();
+  }
+};
+
+export {
+  register,
+  collectDefaultMetrics,
+  playerGuessesCounter,
+  correctGuessesCounter,
+  uniquePlayersCounter,
+  trackUniquePlayer
+};


### PR DESCRIPTION
## Summary
- track unique player count with Prometheus counter
- count unique player IPs when checking songs
- document new `unique_players_total` KPI

## Testing
- `npm test` *(fails: ENETUNREACH during Spotify API requests; 7 passed, 3 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a759b88bb88324a78a99df2387a1f7