### PR TITLE
Expose metrics port for monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ FROM base AS dev
 ENV NODE_ENV=development
 ENV PORT=3000
 ENV HOST=0.0.0.0
+ENV METRICS_PORT=9100
 
 WORKDIR /app
 
@@ -48,7 +49,7 @@ USER blindtest
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider --timeout=5 --header="x-health-check: true" http://localhost:3000/health || exit 1
 
-EXPOSE 3000
+EXPOSE 3000 9100
 
 # Point d'entrée pour le développement
 ENTRYPOINT ["/sbin/tini", "--"]
@@ -60,6 +61,7 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
+ENV METRICS_PORT=9100
 
 WORKDIR /app
 
@@ -80,7 +82,7 @@ USER blindtest
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider --timeout=5 --header="x-health-check: true" http://localhost:3000/health || exit 1
 
-EXPOSE 3000
+EXPOSE 3000 9100
 
 # Utiliser tini comme init système pour une gestion propre des signaux
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -299,6 +299,15 @@ Ajoute une tâche cron sur l'hôte pour renouveler les certificats et recharger 
 
 ## Déploiement en production
 
+### Podman
+
+Le script `scripts/deploy-production.sh` utilise **Podman**. Lors d'un déploiement manuel, pensez à exposer également le port des métriques :
+
+```bash
+sudo podman pod create -p 80:80 -p 443:443 -p 9100:9100
+sudo podman run --pod blindtest -e METRICS_PORT=9100 ...
+```
+
 Pour exposer l'application sur Internet, il est conseillé de placer le serveur Node derrière un reverse proxy **Nginx** et de protéger les connexions HTTPS avec **Let's Encrypt**.
 
 ### Configuration Nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - HOST=0.0.0.0
+      - METRICS_PORT=9100
       - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
       - SPOTIFY_REDIRECT_URI=${SPOTIFY_REDIRECT_URI}
@@ -24,6 +25,9 @@ services:
     restart: unless-stopped
     expose:
       - "3000"
+      - "9100"
+    ports:
+      - "9100:9100"
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "--timeout=5", "http://localhost:3000/health"]
       interval: 30s

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -718,7 +718,7 @@ ok "✅ Nettoyage terminé"
 log "📦 Création du pod $POD_NAME avec ports 80/443..."
 sudo podman pod create \
     --name "$POD_NAME" \
-    -p 80:80 -p 443:443
+    -p 80:80 -p 443:443 -p 9100:9100
 ok "✅ Pod créé"
 
 # Démarrage de l'application dans le pod
@@ -731,6 +731,7 @@ sudo podman run -d \
     -e NODE_ENV=production \
     -e PORT=3000 \
     -e HOST=0.0.0.0 \
+    -e METRICS_PORT=9100 \
     --health-cmd='wget --no-verbose --tries=1 --spider --timeout=5 http://127.0.0.1:3000/health || exit 1' \
     --health-interval=30s \
     --health-timeout=10s \


### PR DESCRIPTION
## Summary
- expose metrics port 9100 in Dockerfile and runtime scripts
- map metrics port in docker-compose and Podman deployment
- document Podman usage for metrics

## Testing
- `npm test` *(fails: SPOTIFY_CLIENT_ID manquant, ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a75bc6a818832494cd44eb127118be